### PR TITLE
Improved the tests for _fitting.py, added _argmin_chi2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,8 @@ demos/didv/*.png
 ### ignore the document build folder
 docs/_build/*
 
+### ignore code coverage generated files
+.coverage
+*.png
+
 

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -2,6 +2,34 @@ import numpy as np
 import qetpy as qp
 from qetpy import ofamp, chi2lowfreq, OFnonlin, MuonTailFit
 
+
+def isclose(a, b, rtol=1e-13, atol=0):
+    """
+    Function for checking if two arrays are close up to certain tolerance parameters.
+    This is a wrapper for `numpy.isclose`, where we have simply changed the default 
+    parameters.
+    
+    Parameters
+    ----------
+    a : array_like
+        Input array to compare.
+    b : array_like
+        Input array to compare.
+    rtol : float, optional
+        The relative tolerance parameter.
+    atol : float, optional
+        The absolute tolerance parameter.
+
+    Returns
+    -------
+    y : bool
+        Returns a boolean value of whether all values of `a` and `b`
+        were equal within the given tolerance.
+    
+    """
+    
+    return np.all(np.isclose(a, b, rtol=rtol, atol=atol))
+
 def create_example_data(lgcpileup=False, lgcbaseline=False):
     """
     Function written for creating example data when testing different
@@ -68,38 +96,38 @@ def test_OptimumFilter():
 
     OF = qp.OptimumFilter(signal, template, psd, fs)
     res = OF.ofamp_nodelay()
-    assert res == (-1.589803642041125e-07, 2871569.457990007)
-    
+    assert isclose(res, (-1.589803642041125e-07, 2871569.457990007))
+
     res = OF.ofamp_withdelay()
-    assert res == (4.000884927004103e-06, 0.00016, 32474.45440205792)
+    assert isclose(res, (4.000884927004103e-06, 0.00016, 32474.45440205792))
     
     res = OF.ofamp_withdelay(nconstrain=100)
-    assert res == (6.382904231454342e-07, 7.84e-05, 2803684.0424425197)
+    assert isclose(res, (6.382904231454342e-07, 7.84e-05, 2803684.0424425197))
 
     res = OF.ofamp_withdelay(nconstrain=100, lgcoutsidewindow=True)
-    assert res == (4.000884927004103e-06, 0.00016, 32474.45440205792)
+    assert isclose(res, (4.000884927004103e-06, 0.00016, 32474.45440205792))
     
     res = OF.chi2_lowfreq(amp=4.000884927004103e-06, t0=0.00016, fcutoff=10000)
-    assert res == 1052.9089578293142
+    assert isclose(res, 1052.9089578293142)
     
     res = OF.chi2_nopulse()
-    assert res == 2876059.4034037213
+    assert isclose(res, 2876059.4034037213)
     
     res = OF.ofamp_pileup_stationary()
-    assert res == (2.884298804131357e-09, 4.001001614298674e-06, 0.00016, 32472.978956471197)
+    assert isclose(res, (2.884298804131357e-09, 4.001001614298674e-06, 0.00016, 32472.978956471197))
     
     signal, template, psd = create_example_data(lgcpileup=True)
     
     OF.update_signal(signal)
     res = OF.ofamp_withdelay()
     res = OF.ofamp_pileup_iterative(res[0], res[1])
-    assert res == (4.000882414471985e-06, 0.00016, 32477.55571848713)
+    assert isclose(res, (4.000882414471985e-06, 0.00016, 32477.55571848713))
     
     signal, template, psd = create_example_data(lgcbaseline=True)
     
     OF.update_signal(signal)
     res = OF.ofamp_baseline()
-    assert res == (4.000884927004102e-06, 0.00016, 32474.454402058076)
+    assert isclose(res, (4.000884927004102e-06, 0.00016, 32474.454402058076))
     
     
 def test_ofamp():

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -3,7 +3,7 @@ import qetpy as qp
 from qetpy import ofamp, chi2lowfreq, OFnonlin, MuonTailFit
 
 
-def isclose(a, b, rtol=1e-13, atol=0):
+def isclose(a, b, rtol=1e-10, atol=0):
     """
     Function for checking if two arrays are close up to certain tolerance parameters.
     This is a wrapper for `numpy.isclose`, where we have simply changed the default 

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -97,9 +97,15 @@ def test_OptimumFilter():
     OF = qp.OptimumFilter(signal, template, psd, fs)
     res = OF.ofamp_nodelay()
     assert isclose(res, (-1.589803642041125e-07, 2871569.457990007))
+    
+    res = OF.energy_resolution()
+    assert isclose(res, 2.3725914280425287e-09)
 
     res = OF.ofamp_withdelay()
     assert isclose(res, (4.000884927004103e-06, 0.00016, 32474.45440205792))
+    
+    res = OF.time_resolution(res[0])
+    assert isclose(res, 5.746611055379949e-09)
     
     res = OF.ofamp_withdelay(nconstrain=100)
     assert isclose(res, (6.382904231454342e-07, 7.84e-05, 2803684.0424425197))

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -1,7 +1,6 @@
 import numpy as np
 import qetpy as qp
-from qetpy import ofamp, chi2lowfreq, OFnonlin, MuonTailFit
-
+from qetpy.core._fitting import _argmin_chi2
 
 def isclose(a, b, rtol=1e-10, atol=0):
     """
@@ -85,9 +84,70 @@ def create_example_data(lgcpileup=False, lgcbaseline=False):
 
     return signal, template, psd_sim
 
+def create_example_muontail():
+    """
+    Function written for creating an example muon tail for 
+    testing `qetpy.MuonTailFit`.
+    
+    Parameters
+    ----------
+    None
+        
+    Returns
+    -------
+    signal : ndarray
+        An array of values containing the specified signal in time domain, including
+        some noise.
+    psd_sim : ndarray
+        The two-sided power spectral density used to generate the noise for `signal`.
+    
+    """
+
+    np.random.seed(1) # need to specify the random seed for testing
+
+    fs = 625e3
+    tau_fall = 20e-3
+    pulse_amp = 0.5e-6
+
+    f = np.fft.fftfreq(32500, d=1/fs)
+    noisesim = qp.sim.TESnoise(r0=0.03)
+
+    psd_sim = noisesim.s_iload(freqs=f) + noisesim.s_ites(freqs=f) + noisesim.s_itfn(freqs=f)
+
+    t = np.arange(len(psd_sim))/fs
+    
+    pulse = np.exp(-t/tau_fall)
+    template = pulse/pulse.max()
+    
+    noise = qp.gen_noise(psd_sim, fs=fs, ntraces=1)[0]
+    signal = noise + template * pulse_amp
+
+    return signal, psd_sim
+
+def test_argmin_chi2():
+    """
+    Testing function for `qetpy.core._fitting._argmin_chi2`.
+    
+    """
+    
+    np.random.seed(1)
+    
+    x = np.random.rand(100)
+    
+    res1 = _argmin_chi2(x)
+    res2 = _argmin_chi2(x, nconstrain=20)
+    res3 = _argmin_chi2(x, nconstrain=20, lgcoutsidewindow=True)
+    res4 = _argmin_chi2(x, nconstrain=1000)
+    
+    assert res1 == 2
+    assert res2 == 50
+    assert res3 == 2
+    assert res4 == 2
+    
+
 def test_OptimumFilter():
     """
-    Testing function for qetpy.OptimumFilter class.
+    Testing function for `qetpy.OptimumFilter` class.
     
     """
 
@@ -119,14 +179,21 @@ def test_OptimumFilter():
     res = OF.chi2_nopulse()
     assert isclose(res, 2876059.4034037213)
     
+    OF.update_signal(signal)
     res = OF.ofamp_pileup_stationary()
     assert isclose(res, (2.884298804131357e-09, 4.001001614298674e-06, 0.00016, 32472.978956471197))
     
     signal, template, psd = create_example_data(lgcpileup=True)
     
     OF.update_signal(signal)
-    res = OF.ofamp_withdelay()
-    res = OF.ofamp_pileup_iterative(res[0], res[1])
+    res1 = OF.ofamp_withdelay()
+    res = OF.ofamp_pileup_iterative(res1[0], res1[1])
+    assert isclose(res, (4.000882414471985e-06, 0.00016, 32477.55571848713))
+
+    res = OF.ofamp_pileup_iterative(res1[0], res1[1], nconstrain=100, lgcoutsidewindow=False)
+    assert isclose(res, (6.382879106117655e-07, 7.84e-05, 2803684.142039136))
+    
+    res = OF.ofamp_pileup_iterative(res1[0], res1[1], nconstrain=100, lgcoutsidewindow=True)
     assert isclose(res, (4.000882414471985e-06, 0.00016, 32477.55571848713))
     
     signal, template, psd = create_example_data(lgcbaseline=True)
@@ -135,103 +202,140 @@ def test_OptimumFilter():
     res = OF.ofamp_baseline()
     assert isclose(res, (4.000884927004102e-06, 0.00016, 32474.454402058076))
     
+    res = OF.ofamp_baseline(nconstrain=100)
+    assert isclose(res, (6.434754982839688e-07, 7.84e-05, 2806781.3450564747))
+    
+    res = OF.ofamp_baseline(nconstrain=100, lgcoutsidewindow=True)
+    assert isclose(res, (4.000884927004102e-06, 0.00016, 32474.454402058076))
+    
     
 def test_ofamp():
-    fs = 625e3
-    tracelength = 32000
-    psd = np.ones(tracelength)
-
-    # Dummy pulse template
-    nbin = len(psd)
-    ind_trigger = round(nbin/2)
-    tt = 1.0/fs *(np.arange(1, nbin+1)-ind_trigger)
-    lgc_b0 = tt < 0.0
-
-    # pulse shape
-    tau_rise = 20.0e-6
-    tau_fall = 80.0e-6
-    template = np.exp(-tt/tau_fall)-np.exp(-tt/tau_rise)
-    template[lgc_b0] = 0.0
-    template = template/max(template)
-    signal = template + np.random.randn(len(template))/10
-    signal = np.roll(signal,20)
-    res = ofamp(signal, template, psd, fs, lgcsigma=True, nconstrain=100, withdelay=True)
+    """
+    Testing function for `qetpy.ofamp`.
     
-    assert len(res)>0
+    """
+    
+    signal, template, psd = create_example_data()
+    fs = 625e3
+    
+    res1 = qp.ofamp(signal, template, psd, fs, lgcsigma=True, nconstrain=100, withdelay=True)
+    
+    OF = qp.OptimumFilter(signal, template, psd, fs)
+    res2 = OF.ofamp_withdelay(nconstrain=100)
+    
+    res_compare = res2 + (OF.energy_resolution(), )
+    
+    assert isclose(res1, res_compare)
+    
+def test_ofamp_pileup():
+    """
+    Testing function for `qetpy.ofamp_pileup`.
+    
+    """
+    signal, template, psd = create_example_data(lgcpileup=True)
+    fs = 625e3
+    
+    res1 = qp.ofamp_pileup(signal, template, psd, fs)
+
+    OF = qp.OptimumFilter(signal, template, psd, fs)
+    res2 = OF.ofamp_withdelay()
+    res3 = OF.ofamp_pileup_iterative(res2[0], res2[1])
+
+    res_compare = res2[:-1] + res3
+    
+    assert isclose(res1, res_compare)
+    
+def test_ofamp_pileup_stationary():
+    """
+    Testing function for `qetpy.ofamp_pileup_stationary`.
+    
+    """
+    
+    signal, template, psd = create_example_data()
+    fs = 625e3
+    
+    res1 = qp.ofamp_pileup_stationary(signal, template, psd, fs)
+
+    OF = qp.OptimumFilter(signal, template, psd, fs)
+    res2 = OF.ofamp_pileup_stationary()
+    
+    assert isclose(res1, res2)
     
 def test_chi2lowfreq():
-    fs = 625e3
-    tracelength = 32000
-    psd = np.ones(tracelength)
-
-    # Dummy pulse template
-    nbin = len(psd)
-    ind_trigger = round(nbin/2)
-    tt = 1.0/fs *(np.arange(1, nbin+1)-ind_trigger)
-    lgc_b0 = tt < 0.0
-
-    # pulse shape
-    tau_rise = 20.0e-6
-    tau_fall = 80.0e-6
-    template = np.exp(-tt/tau_fall)-np.exp(-tt/tau_rise)
-    template[lgc_b0] = 0.0
-    template = template/max(template)
-    signal = template + np.random.randn(len(template))/10
-    signal = np.roll(signal,20)
-    res = ofamp(signal, template, psd, fs, lgcsigma=True, nconstrain=100)
-
-    chi2low = chi2lowfreq(signal, template, res[0], res[1], psd, fs)
+    """
+    Testing function for `qetpy.chi2lowfreq`.
     
-    assert chi2low>0
+    """
+    
+    signal, template, psd = create_example_data()
+    fs=625e3
+    
+    res1 = qp.ofamp(signal, template, psd, fs)
+
+    chi2low = qp.chi2lowfreq(signal, template, res1[0], res1[1], psd, fs, fcutoff=10000)
+    
+    OF = qp.OptimumFilter(signal, template, psd, fs)
+    res2 = OF.ofamp_withdelay()
+    chi2low_compare = OF.chi2_lowfreq(amp=res2[0], t0=res2[1], fcutoff=10000)
+    
+    assert isclose(chi2low, chi2low_compare)
+    
+def test_chi2_nopulse():
+    """
+    Testing function for `qetpy.chi2_nopulse`.
+    
+    """
+    
+    signal, template, psd = create_example_data()
+    fs=625e3
+    
+    res1 = qp.chi2_nopulse(signal, psd, fs)
+        
+    OF = qp.OptimumFilter(signal, template, psd, fs)
+    res2 = OF.chi2_nopulse()
+    
+    assert isclose(res1, res2)
     
 def test_OFnonlin():
-
-    fs = 625e3
-    tracelength = 32000
-    psd = np.ones(tracelength)
-
-    # Dummy pulse template
-    nbin = len(psd)
-    ind_trigger = round(nbin/2)
-    tt = 1.0/fs *(np.arange(1, nbin+1)-ind_trigger)
-    lgc_b0 = tt < 0.0
-
-    # pulse shape
-    tau_rise = 20.0e-6
-    tau_fall = 80.0e-6
-    template = np.exp(-tt/tau_fall)-np.exp(-tt/tau_rise)
-    template[lgc_b0] = 0.0
-    template = template/max(template)
-    signal = template + np.random.randn(len(template))/10
-    signal = np.roll(signal, 20)
-
-    nlin = OFnonlin(psd, fs, template=template)
-    res1 = nlin.fit_falltimes(signal, npolefit=2, lgcfullrtn=True, lgcplot=True)
-    res2 = nlin.fit_falltimes(signal, npolefit=1, lgcfullrtn=True, lgcplot=True, taurise=20e-6)
+    """
+    Testing function for `qetpy.OFnonlin` class.
     
-    assert len(res1)>0
-    assert len(res2)>0
+    """
+
+    signal, template, psd = create_example_data()
+    fs=625e3
+    
+    signal = np.roll(signal, -100) # undo the roll in create_example_data to make test easier
+    
+    nlin = qp.OFnonlin(psd, fs, template=template)
+    res1 = nlin.fit_falltimes(signal, npolefit=1, lgcfullrtn=False, lgcplot=True, taurise=20e-6)
+    res2 = nlin.fit_falltimes(signal, npolefit=2, lgcfullrtn=False, lgcplot=True)
+    res3 = nlin.fit_falltimes(signal, npolefit=3, lgcfullrtn=False, lgcplot=True)
+    res4 = nlin.fit_falltimes(signal, npolefit=4, lgcfullrtn=False, lgcplot=True)
+    
+    assert isclose(res1, [4.008696926367952e-06, 6.577134966380607e-05,
+                          2.600003126086262e-02])
+    assert isclose(res2, [4.010777893773002e-06, 1.952058681743049e-05,
+                          6.667391354400329e-05, 2.600012092917421e-02])
+    assert isclose(res3, [9.500874702974979e-06, 3.741145454838031e-07, 
+                          3.009347194816780e-05, 6.564912869450656e-05, 
+                          3.936529481598184e-05, 2.600108092211354e-02])
+    assert isclose(res4, [9.641786698864857e-06, 3.600761403100650e-07,
+                          1.455031180770612e-08, 3.122359014566530e-05, 
+                          6.252538026298095e-05, 1.148536559396062e-04,
+                          5.654910608438102e-05, 2.600107408493412e-02])
     
 def test_MuonTailFit():
+    """
+    Testing function for `qetpy.MuonTailFit` class.
     
+    """
+    
+    signal, psd = create_example_muontail()    
     fs = 625e3
-    tracelength = 32000
-    psd = np.ones(tracelength)
-
-    # Dummy pulse template
-    nbin = len(psd)
-    ind_trigger = 0
-    tt = 1.0/fs *(np.arange(1, nbin+1)-ind_trigger)
-    lgc_b0 = tt < 0.0
-
-    # pulse shape
-    tau_fall = 20e-3
-    template = np.exp(-tt/tau_fall)
-    template[lgc_b0] = 0.0
-    template = template/max(template)
-    signal = template + np.random.randn(len(template))/10
-
-    mtail = MuonTailFit(psd, fs)
-    res = mtail.fitmuontail(signal, lgcfullrtn=True)
     
-    assert len(res)>0
+    mtail = qp.MuonTailFit(psd, fs)
+    res = mtail.fitmuontail(signal, lgcfullrtn=False)
+    
+    assert isclose(res, [4.596452407352775e-07, 2.018680240688412e-02])
+    


### PR DESCRIPTION
I created some better and more complete tests for the functions in `_fitting.py`. This was in response to Issue #23. We still need to improve the tests further, but this is a good start.

Note that for some reason the Travis CI build fails on `qetpy.OptimumFilter.ofamp_pileup_stationary` 50% of the time, where the output is NaN. In this case, restarting the build fixes it, but the reason for this is unclear to me.

I also added a hidden helper function called `_argmin_chi2` that does the constrained windowing for any inputted \chi^2. The reason for this being that the same code was repeated in almost every function in `_fitting.py`, so it made since to just make it a function that is called by each function.

Some typos in the documentation were also fixed. And `qetpy.chi2lowfreq` now has an AC-coupled option.