### PR TITLE
Maintenance/array energy calc

### DIFF
--- a/qetpy/utils/_utils.py
+++ b/qetpy/utils/_utils.py
@@ -325,8 +325,7 @@ def powertrace_simple(trace, ioffset, qetbias, rload, rsh):
     Parameters
     ----------
     trace : ndarray
-        Time series traces of shape (# traces, # channels, # bins per channel),
-        referenced to TES current
+        Time series traces, where the last dimension is the trace length, referenced to TES current.
     ioffset : float
         The offset in the measured TES current
     qetbias : float
@@ -359,8 +358,7 @@ def integrate_powertrace_simple(trace, time, nbasepre, nbasepost, ioffset, qetbi
     Parameters
     ----------
     trace : ndarray
-        Time series traces of shape (# traces, # channels, # bins per channel),
-        referenced to TES current
+        Time series traces, where the last dimension is the trace length, referenced to TES current.
     time : ndarray
         Array of time values corresponding to the trace array
     nbasepre : int

--- a/qetpy/utils/_utils.py
+++ b/qetpy/utils/_utils.py
@@ -316,14 +316,17 @@ def get_offset_from_muon(avemuon, qetbias, rn, rload, rsh=5e-3, nbaseline=6000, 
 def powertrace_simple(trace, ioffset,qetbias, rload, rsh):
     """
     Function to convert time series trace from units of TES current to units of power.
+    This can be done for either a single trace, or an array of traces, as
+    long as the first dimension is the number of traces.
     
     The function takes into account the second order depenace on current, but assumes
     the infinite irwin loop gain approximation. 
     
     Parameters
     ----------
-    trace : array
-        Time series trace, referenced to TES current
+    trace : narray
+        Time series traces of shape (# traces, # channels, # bins per channel),
+        referenced to TES current
     ioffset : float
         The offset in the measured TES current
     qetbias : float
@@ -341,7 +344,7 @@ def powertrace_simple(trace, ioffset,qetbias, rload, rsh):
     """
     
     vbias = qetbias*rsh
-    trace_i0 = trace - qetoffset
+    trace_i0 = trace - ioffset
     trace_p = trace_i0*vbias - (rload)*trace_i0**2
     
     return trace_p
@@ -350,12 +353,14 @@ def powertrace_simple(trace, ioffset,qetbias, rload, rsh):
 def integrate_powertrace_simple(trace, time, nbasepre, nbasepost, ioffset, qetbias, rload, rsh):
     """
     Function to calculate the energy collected by the TESs by integrating the power in the TES 
-    as a function of time. 
+    as a function of time. This can be done for either a single trace, or an array of traces, as
+    long as the first dimension is the number of traces.
     
     Parameters
     ----------
     trace : array
-        Time series trace, referenced to TES current
+        Time series traces of shape (# traces, # channels, # bins per channel),
+        referenced to TES current
     time : array
         Array of time values corresponding to the trace array
     nbasepre : int
@@ -378,11 +383,11 @@ def integrate_powertrace_simple(trace, time, nbasepre, nbasepost, ioffset, qetbi
         
     """
     
-    baseline = np.mean(np.hstack((trace[:nbasepre],trace[nbasepost:])))
+    baseline = np.mean(np.hstack((trace[..., :nbasepre],trace[..., nbasepost:])), axis = -1, keepdims=True)
     baseline_p0 = powertrace_simple(baseline, ioffset,qetbias,rload, rsh)
-    
     trace_power = powertrace_simple(trace, ioffset,qetbias,rload, rsh)
-    integrated_energy = np.trapz(baseline_p0 - trace_power, x = time)/constants.e 
+    
+    integrated_energy = np.trapz(baseline_p0 - trace_power, x = time, axis = -1)/constants.e 
     
     return integrated_energy
                                

--- a/qetpy/utils/_utils.py
+++ b/qetpy/utils/_utils.py
@@ -261,7 +261,7 @@ def get_offset_from_muon(avemuon, qetbias, rn, rload, rsh=5e-3, nbaseline=6000, 
     
     Parameters
     ----------
-    avemuon : array
+    avemuon : ndarray
         An average of 'good' muons in time domain, referenced to TES current
     qetbias : float
         Applied QET bias current
@@ -313,18 +313,18 @@ def get_offset_from_muon(avemuon, qetbias, rn, rload, rsh=5e-3, nbaseline=6000, 
                                
                                
                                
-def powertrace_simple(trace, ioffset,qetbias, rload, rsh):
+def powertrace_simple(trace, ioffset, qetbias, rload, rsh):
     """
     Function to convert time series trace from units of TES current to units of power.
     This can be done for either a single trace, or an array of traces, as
     long as the first dimension is the number of traces.
     
-    The function takes into account the second order depenace on current, but assumes
+    The function takes into account the second order dependence on current, but assumes
     the infinite irwin loop gain approximation. 
     
     Parameters
     ----------
-    trace : narray
+    trace : ndarray
         Time series traces of shape (# traces, # channels, # bins per channel),
         referenced to TES current
     ioffset : float
@@ -333,12 +333,12 @@ def powertrace_simple(trace, ioffset,qetbias, rload, rsh):
         Applied QET bias current
     rload : float
         Load resistance of TES circuit (rp + rsh)
-    rsh : float, optional
+    rsh : float
         Value of the shunt resistor for the TES circuit
         
     Returns
     -------
-    trace_p : array
+    trace_p : ndarray
         Time series trace, in units of power referenced to the TES
         
     """
@@ -358,10 +358,10 @@ def integrate_powertrace_simple(trace, time, nbasepre, nbasepost, ioffset, qetbi
     
     Parameters
     ----------
-    trace : array
+    trace : ndarray
         Time series traces of shape (# traces, # channels, # bins per channel),
         referenced to TES current
-    time : array
+    time : ndarray
         Array of time values corresponding to the trace array
     nbasepre : int
         The bin number corresponding to the pre-pulse baseline, i.e. [0:nbasepre]
@@ -373,12 +373,12 @@ def integrate_powertrace_simple(trace, time, nbasepre, nbasepost, ioffset, qetbi
         Applied QET bias current
     rload : float
         Load resistance of TES circuit (rp + rsh)
-    rsh : float, optional
+    rsh : float
         Value of the shunt resistor for the TES circuit
     
     Returns
     -------
-    integrated_energy : float
+    integrated_energy : float, ndarray
         The energy absorbed by the TES in units of eV
         
     """

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 from qetpy import calc_psd
 from qetpy.cut import removeoutliers, iterstat
-from qetpy.utils import stdcomplex, lowpassfilter, align_traces, calc_offset
+from qetpy.utils import stdcomplex, lowpassfilter, align_traces, calc_offset, integrate_powertrace_simple, powertrace_simple
 
 def test_align_traces():
     traces = np.random.randn(100, 32000)
@@ -46,3 +46,25 @@ def test_lowpassfilter():
     res = lowpassfilter(traces)
     
     assert res.shape == traces.shape
+    
+def test_powertrace_simple():
+    test_traces = 4*np.ones(shape = (10,10))
+    power_test = powertrace_simple(trace = test_traces, 
+                ioffset = 1, qetbias = 1, rload = 1, rsh = 1)
+    
+    assert np.all(power_test == -6)
+    
+def test_integrate_powertrace_simple():
+    test_traces = np.zeros(shape=100)
+    test_traces[50:75] = 2
+    energy = integrate_powertrace_simple(trace=test_traces, 
+                                time=np.arange(100)*1e-20,
+                                nbasepre=0,
+                                nbasepost=75, 
+                                ioffset=0, 
+                                qetbias=1, 
+                                rload=1, 
+                                rsh=1)
+    assert int(energy) == 3
+    
+


### PR DESCRIPTION
Added ability for ndarray of traces to be converted to power, and integrated to calculate absorbed energy with ```qetpy.utils.powertrace_simple()``` and ```qetpy.utils.integrate_powertrace_simple``` respectively.

I also made tests for these functions. 