### PR TITLE
Add default pre-commit hooks for linting and styling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-docstring-first
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: requirements-txt-fixer
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.1
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.3
+    hooks:
+    -   id: autopep8
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v1.11.1
+    hooks:
+    -   id: pyupgrade
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v1.3.5
+    hooks:
+    -   id: reorder-python-imports
+        language_version: python3
+-   repo: https://github.com/asottile/add-trailing-comma
+    rev: v0.7.1
+    hooks:
+    -   id: add-trailing-comma
+-   repo: meta
+    hooks:
+    -   id: check-hooks-apply
+    -   id: check-useless-excludes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 h5py==2.7.1
 matplotlib==2.2.2
+nbsphinx==0.3.5
 numpy==1.14.3
 numpydoc==0.8.0
+pre-commit==1.14.4
 scipy==1.1.0
 seaborn==0.8.1
 Sphinx==1.6.3
 sphinx-rtd-theme==0.4.1
 sphinxcontrib-websupport==1.0.1
-nbsphinx==0.3.5


### PR DESCRIPTION
https://pre-commit.com/ 

Before each commit, a few linters will run for each file that was changed. Ran `pre-commit run --all-files` and found a ton of issues (mostly just removing trailing whitespace), but this is also good for finding unused imports and variables. 