### PR TITLE
Add make_template and shift functions to utils

### DIFF
--- a/qetpy/utils/_utils.py
+++ b/qetpy/utils/_utils.py
@@ -1,12 +1,85 @@
 import numpy as np
 from scipy import interpolate, signal, constants
-from scipy.ndimage.interpolation import shift
+from scipy import ndimage
 
 
 __all__ = ["make_decreasing", "calc_offset", "lowpassfilter", "align_traces", "get_offset_from_muon",
            "powertrace_simple", "energy_absorbed", "stdcomplex", "slope",
-           "fill_negatives"]
+           "fill_negatives", "shift", "make_template"]
 
+
+def shift(arr, num, fill_value=0):
+    """
+    Function for shifting the values in an array by a certain number of indices, filling
+    the values of the bins at the head or tail of the array with fill_value.
+    
+    Parameters
+    ----------
+    arr : array_like
+        Array to shift values in.
+    num : float
+        The number of values to shift by. If positive, values shift to the right. If negative, 
+        values shift to the left.
+        If num is a non-whole number of bins, arr is linearly interpolated
+    fill_value : scalar, optional
+        The value to fill the bins at the head or tail of the array with.
+    
+    Returns
+    -------
+    result : ndarray
+        The resulting array that has been shifted and filled in.
+    
+    """
+    
+    result = np.empty_like(arr)
+    
+    if float(num).is_integer():
+        num = int(num) # force num to int type for slicing
+        
+        if num > 0:
+            result[:num] = fill_value
+            result[num:] = arr[:-num]
+        elif num < 0:
+            result[num:] = fill_value
+            result[:num] = arr[-num:]
+        else:
+            result[:] = arr
+    else:
+        result = ndimage.shift(arr, num, order=1, mode='constant', cval=fill_value)
+        
+    return result
+
+
+def make_template(t, tau_r, tau_f, offset=0):
+    """
+    Function to make an ideal pulse template in time domain with single pole exponential rise
+    and fall times, and a given time offset. The template will be returned with the maximum
+    pulse height normalized to one. The pulse, by default, begins at the center of the trace, 
+    which can be left or right shifted via the `offset` optional argument.
+    
+    Parameters
+    ----------
+    t : ndarray
+        Array of time values to make the pulse with
+    tau_r : float
+        The time constant for the exponential rise of the pulse
+    tau_f : float
+        The time constant for the exponential fall of the pulse
+    offset : int
+        The number of bins the pulse template should be shifted
+        
+    Returns
+    -------
+    template_normed : array
+        the pulse template in time domain
+        
+    """
+    
+    pulse = np.exp(-t/tau_f)-np.exp(-t/tau_r)
+    pulse_shifted = shift(pulse, len(t)//2 + offset)
+    template_normed = pulse_shifted/pulse_shifted.max()
+    
+    return template_normed
 
 def make_decreasing(y, x=None):
     """
@@ -241,7 +314,7 @@ def align_traces(traces, lgcjustshifts = False, n_cut = 5000, cut_off_freq = 500
         t2_shift = np.argmax(signal.fftconvolve(t1,t2[::-1],mode = 'full'))-orig
         shifts[ii] = t2_shift
         if not lgcjustshifts:
-            traces_aligned[ii] = shift(traces[ii],t2_shift,cval = np.NAN)
+            traces_aligned[ii] = ndimage.shift(traces[ii], t2_shift, cval=np.nan)
 
     if lgcjustshifts:
         return shifts

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -15,21 +15,21 @@ def test_shift():
     res1 = np.zeros(10)
     res1[3:] = np.arange(7)
 
-    assert np.all(qp.utils.shift(arr, 3) == res1)
+    assert np.all(shift(arr, 3) == res1)
     
     res2 = np.zeros(10)
     res2[:7] = np.arange(10)[-7:]
 
-    assert np.all(qp.utils.shift(arr, -3) == res2)
+    assert np.all(shift(arr, -3) == res2)
     
     res3 = np.arange(10)
     
-    assert np.all(qp.utils.shift(arr, 0) == res3)
+    assert np.all(shift(arr, 0) == res3)
     
     res4 = np.ones(10)
     res4[:9] = np.linspace(0.5, 8.5, num=9)
     
-    assert np.all(qp.utils.shift(arr, -0.5, fill_value=1) == res4)
+    assert np.all(shift(arr, -0.5, fill_value=1) == res4)
 
 def test_align_traces():
     traces = np.random.randn(100, 32000)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,7 +2,34 @@ import pytest
 import numpy as np
 from qetpy import calc_psd
 from qetpy.cut import removeoutliers, iterstat
-from qetpy.utils import stdcomplex, lowpassfilter, align_traces, calc_offset, energy_absorbed, powertrace_simple
+from qetpy.utils import stdcomplex, lowpassfilter, align_traces, calc_offset, energy_absorbed, powertrace_simple, shift
+
+def test_shift():
+    """
+    Testing function for `qetpy.utils.shift`.
+    
+    """
+    
+    arr = np.arange(10, dtype=float)
+    
+    res1 = np.zeros(10)
+    res1[3:] = np.arange(7)
+
+    assert np.all(qp.utils.shift(arr, 3) == res1)
+    
+    res2 = np.zeros(10)
+    res2[:7] = np.arange(10)[-7:]
+
+    assert np.all(qp.utils.shift(arr, -3) == res2)
+    
+    res3 = np.arange(10)
+    
+    assert np.all(qp.utils.shift(arr, 0) == res3)
+    
+    res4 = np.ones(10)
+    res4[:9] = np.linspace(0.5, 8.5, num=9)
+    
+    assert np.all(qp.utils.shift(arr, -0.5, fill_value=1) == res4)
 
 def test_align_traces():
     traces = np.random.randn(100, 32000)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,6 +4,33 @@ from qetpy import calc_psd
 from qetpy.cut import removeoutliers, iterstat
 from qetpy.utils import stdcomplex, lowpassfilter, align_traces, calc_offset, energy_absorbed, powertrace_simple, shift
 
+def isclose(a, b, rtol=1e-10, atol=0):
+    """
+    Function for checking if two arrays are close up to certain tolerance parameters.
+    This is a wrapper for `numpy.isclose`, where we have simply changed the default 
+    parameters.
+    
+    Parameters
+    ----------
+    a : array_like
+        Input array to compare.
+    b : array_like
+        Input array to compare.
+    rtol : float, optional
+        The relative tolerance parameter.
+    atol : float, optional
+        The absolute tolerance parameter.
+
+    Returns
+    -------
+    y : bool
+        Returns a boolean value of whether all values of `a` and `b`
+        were equal within the given tolerance.
+    
+    """
+    
+    return np.all(np.isclose(a, b, rtol=rtol, atol=atol))
+
 def test_shift():
     """
     Testing function for `qetpy.utils.shift`.
@@ -30,6 +57,26 @@ def test_shift():
     res4[:9] = np.linspace(0.5, 8.5, num=9)
     
     assert np.all(shift(arr, -0.5, fill_value=1) == res4)
+    
+def test_make_template():
+    """
+    Testing function for `qetpy.utils.make_template`.
+    
+    """
+    
+    fs = 625e3
+    tau_r = 20e-6
+    tau_f = 80e-6
+    offset = -4
+    time = np.arange(1000)/fs
+    time_offset =  (len(time)//2)/fs + offset/fs
+    
+    # calculate the pulse in an equivalent way, such that the result should be the same
+    pulse = np.heaviside(time - time_offset, 0) 
+    pulse *= (np.exp(-(time - time_offset)/tau_f) - np.exp(-(time - time_offset)/tau_r))
+    pulse /= pulse.max()
+
+    assert isclose(make_template(time, tau_r, tau_f, offset), pulse)
 
 def test_align_traces():
     traces = np.random.randn(100, 32000)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,7 +2,9 @@ import pytest
 import numpy as np
 from qetpy import calc_psd
 from qetpy.cut import removeoutliers, iterstat
-from qetpy.utils import stdcomplex, lowpassfilter, align_traces, calc_offset, energy_absorbed, powertrace_simple, shift
+from qetpy.utils import (stdcomplex, lowpassfilter, align_traces,
+                         calc_offset, energy_absorbed, powertrace_simple,
+                         shift, make_template)
 
 def isclose(a, b, rtol=1e-10, atol=0):
     """


### PR DESCRIPTION
I've added the `make_template` and `shift` functions to the `qetpy.utils` submodule, where they are also `rqpy` functions. This is partially in response to Issue #50, as the `shift` function solves this issue. The `make_template` function makes sense to be in QETpy, so I've added it in the same pull request.