### PR TITLE
Added an option for finding the OF amplitude at a specific time

### DIFF
--- a/qetpy/core/_fitting.py
+++ b/qetpy/core/_fitting.py
@@ -5,8 +5,16 @@ from qetpy.plotting import plotnonlin
 from qetpy.utils import shift
 
 
-__all__ = ["OptimumFilter","ofamp", "ofamp_pileup", "ofamp_pileup_stationary",
-           "chi2lowfreq","chi2_nopulse", "OFnonlin", "MuonTailFit"]
+__all__ = [
+    "OptimumFilter",
+    "ofamp",
+    "ofamp_pileup",
+    "ofamp_pileup_stationary",
+    "chi2lowfreq",
+    "chi2_nopulse",
+    "OFnonlin",
+    "MuonTailFit",
+]
 
 
 def _argmin_chi2(chi2, nconstrain=None, lgcoutsidewindow=False,
@@ -343,29 +351,45 @@ class OptimumFilter(object):
 
         return chi2low
 
-    def ofamp_nodelay(self):
+    def ofamp_nodelay(self, windowcenter=0):
         """
         Function for calculating the optimum amplitude of a pulse in data with no time
-        shifting.
+        shifting, or at a specific time.
+
+        Parameters
+        ----------
+        windowcenter : int, optional
+            The bin, relative to the center bin of the trace, at which to calculate the
+            OF amplitude. Default of 0 calculates the usual no delay optimum filter. Equivalent
+            to calculating the OF amplitude at the bin `self.nbins//2 + windowcenter`. Useful for
+            calculating amplitudes at specific times, if there is some prior knowledge.
 
         Returns
         -------
         amp : float
             The optimum amplitude calculated for the trace (in Amps) with no time shifting
-            allowed.
+            allowed (or at the time specified by `windowcenter`).
         chi2 : float
-            The chi^2 value calculated from the optimum filter with no time shifting.
+            The chi^2 value calculated from the optimum filter with no time shifting (or at the
+            time specified by `windowcenter`).
 
         """
-        # compute OF amplitude no delay
-        amp = np.real(np.sum(self.signalfilt, axis=-1))*self.df
+
+        if windowcenter != 0 and self.freqs is None:
+            self.freqs = fftfreq(self.nbins, d=1.0/self.fs)
+
+        if windowcenter != 0:
+            t0 = windowcenter / self.fs
+            amp = np.real(np.sum(self.signalfilt * np.exp(2.0j * np.pi * t0 * self.freqs), axis=-1)) * self.df
+        else:
+            amp = np.real(np.sum(self.signalfilt, axis=-1)) * self.df
 
         # signal part of chi2
         if self.chi0 is None:
-            self.chi0 = np.real(np.dot(self.v.conjugate()/self.psd, self.v)*self.df)
+            self.chi0 = np.real(np.dot(self.v.conjugate() / self.psd, self.v) * self.df)
 
         # fitting part of chi2
-        chit = (amp**2)*self.norm
+        chit = (amp**2) * self.norm
 
         chi2 = self.chi0 - chit
 

--- a/qetpy/core/_fitting.py
+++ b/qetpy/core/_fitting.py
@@ -241,6 +241,23 @@ class OptimumFilter(object):
         self.times = None
         self.freqs = None
 
+    def _check_freqs(self):
+        """
+        Hidden method for checking if we have initialized the FFT frequencies.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+
+        """
+
+        if self.freqs is None:
+            self.freqs = fftfreq(self.nbins, d=1.0/self.fs)
+
     def update_signal(self, signal):
         """
         Method to update `OptimumFilter` with a new signal if the PSD and template
@@ -293,8 +310,7 @@ class OptimumFilter(object):
 
         """
 
-        if self.freqs is None:
-            self.freqs = fftfreq(self.nbins, d=1.0/self.fs)
+        self._check_freqs()
 
         sigma = 1.0/np.sqrt(amp**2 * np.sum((2*np.pi*self.freqs)**2 * np.abs(self.s)**2 / self.psd) * self.df)
 
@@ -340,8 +356,7 @@ class OptimumFilter(object):
 
         """
 
-        if self.freqs is None:
-            self.freqs = fftfreq(self.nbins, d=1.0/self.fs)
+        self._check_freqs()
 
         chi2tot = self.df*np.abs(self.v-amp*np.exp(-2.0j*np.pi*t0*self.freqs)*self.s)**2/self.psd
 
@@ -375,10 +390,8 @@ class OptimumFilter(object):
 
         """
 
-        if windowcenter != 0 and self.freqs is None:
-            self.freqs = fftfreq(self.nbins, d=1.0/self.fs)
-
         if windowcenter != 0:
+            self._check_freqs()
             t0 = windowcenter / self.fs
             amp = np.real(np.sum(self.signalfilt * np.exp(2.0j * np.pi * t0 * self.freqs), axis=-1)) * self.df
         else:
@@ -523,8 +536,7 @@ class OptimumFilter(object):
 
         """
 
-        if self.freqs is None:
-            self.freqs = fftfreq(self.nbins, d=1.0/self.fs)
+        self._check_freqs()
 
         if self.signalfilt_td is None:
             self.signalfilt_td = np.real(ifft(self.signalfilt*self.nbins, axis=-1))*self.df

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -89,7 +89,10 @@ def test_OptimumFilter():
 
     res = OF.ofamp_withdelay()
     assert isclose(res, (4.000884927004103e-06, 0.00016, 32474.45440205792))
-    
+
+    res2 = OF.ofamp_nodelay(windowcenter=int(res[1] * fs))
+    assert isclose(res2, res[::2])
+
     res = OF.time_resolution(res[0])
     assert isclose(res, 5.746611055379949e-09)
     


### PR DESCRIPTION
I've added the `windowcenter` parameter to the class method `qetpy.OptimumFilter.ofamp_nodelay`, which allows the user to determine the OF amplitude at a specific time shift value, rather than only at zero shifting.

Also refactored the class a little bit, so that the check for if `freqs` attribute was set has been made into its own helper class method `_check_freqs`.