### PR TITLE
Add the optional calculation of the unbiased mean and standard deviation in iterstat

### DIFF
--- a/qetpy/cut/_cut.py
+++ b/qetpy/cut/_cut.py
@@ -129,7 +129,7 @@ class _UnbiasedEstimators(object):
 
         mu_eqn = self._sumx - self._lenx * mu
         # term due to truncation
-        mu_eqn += 1 / (cdf_upr - cdf_lwr) * (pdf_upr - pdf_lwr)
+        mu_eqn += self._lenx / (cdf_upr - cdf_lwr) * (pdf_upr - pdf_lwr)
 
         std_eqn = self._sumx2 - 2 * mu * self._sumx + self._lenx * mu**2 - self._lenx * std**2
         # term due to truncation

--- a/test/test_cut.py
+++ b/test/test_cut.py
@@ -1,6 +1,7 @@
 import qetpy as qp
 import numpy as np
 import pytest
+from qetpy.cut._cut import _UnbiasedEstimators
 
 def test_itercov():
     """Testing function for `qetpy.cut.itercov`."""
@@ -47,3 +48,15 @@ def test_itercov():
 
     arr_in = np.array([[0, 1]])
     assert np.all(qp.cut.itercov(arr_in)[0] == arr_in[0])
+
+def test_UnbiasedEstimators():
+    """Testing function for `qetpy.cut._cut._UnbiasedEstimators`."""
+
+    x = stats.norm.rvs(size=100, random_state=1)
+
+    lwrbnd = -1
+    uprbnd = 1
+
+    unb = _UnbiasedEstimators(x, lwrbnd, uprbnd)
+
+    assert np.allclose((unb.mu, unb.std), (-0.008724932112491217, 0.9540689615563553))

--- a/test/test_cut.py
+++ b/test/test_cut.py
@@ -1,5 +1,6 @@
 import qetpy as qp
 import numpy as np
+from scipy import stats
 import pytest
 from qetpy.cut._cut import _UnbiasedEstimators
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -73,18 +73,6 @@ def test_calc_psd():
 
     assert len(res)>0
 
-def test_iterstat():
-    traces = np.random.randn(100, 32000)
-    offsets = traces.mean(axis=1)
-    res = iterstat(offsets)
-
-    assert len(res)>0
-
-    expected_res_warn = (0, 0, np.array([True]))
-    res_warn = iterstat(np.array([0]))
-
-    assert np.all([np.all(expected_res_warn[ii] == res_warn[ii]) for ii in range(3)])
-
 def test_removeoutliers():
     traces = np.random.randn(100, 32000)
     offsets = traces.mean(axis=1)


### PR DESCRIPTION
I added a hidden class `qetpy.cut._cut._UnbiasedEstimators` which does the calculation of unbiased estimators of a 1D normal distribution given that we have truncated at a lower and upper bound.

This class can be used by `qetpy.cut.iterstat` to return the biased or unbiased estimators, which is determined by the new keyword argument `return_unbiased_estimates`.

I've also included a test for the new class and updated the `iterstat` test to actually be useful.