### PR TITLE
Remove reference to non-existent notebook

### DIFF
--- a/demos/iv/iv_class_test.ipynb
+++ b/demos/iv/iv_class_test.ipynb
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's load the example data. To see how this data was created, look at the `run_31_chips_iv.ipynb` file, which loads the data from Pickle files. This data was created from Run 31 at SLAC, using TES chips. There is no guarantee that that notebook will run."
+    "Let's load the example data provided, which is from a dataset taken at SLAC for multiple devices and multiple bath temperatures."
    ]
   },
   {


### PR DESCRIPTION
The IV demo references a notebook called `run31_chips_iv.ipynb`, which is not provided by QETpy, so we should remove that reference from the notebook, as it can cause confusion.