### PR TITLE
Fix Travis CI Build Error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
   - conda install scipy
   - conda install -c conda-forge matplotlib
   - conda install h5py
-  - conda install seaborn
   # Copy matplotlib configuration so it does not try and plot to 
   # screen, which can cause matplotlib tests to fail.
   - cp test/packages/matplotlibrc .

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # Install packages needed for testing QETpy
   - conda install numpy
   - conda install scipy
-  - conda install matplotlib
+  - conda install -c conda-forge matplotlib
   - conda install h5py
   - conda install seaborn
   # Copy matplotlib configuration so it does not try and plot to 

--- a/condaenv.yml
+++ b/condaenv.yml
@@ -9,7 +9,6 @@ dependencies:
   - pandas=0.23.0=py36h637b7d7_0
   - python=3.6.5=hc3d631a_2
   - scipy=1.1.0=py36hfc37229_0
-  - seaborn=0.8.1=py36hfad7ec4_0
   - sphinx=1.7.4=py36_0
   - sphinxcontrib=1.0=py36h6d0f590_1
   - sphinxcontrib-websupport=1.0.1=py36hb5cb234_1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ numpy>=1.14.3
 numpydoc>=0.8.0
 pre-commit>=1.14.4
 scipy>=1.1.0
-seaborn>=0.8.1
 Sphinx>=1.6.3
 sphinx-rtd-theme>=0.4.1
 sphinxcontrib-websupport>=1.0.1


### PR DESCRIPTION
I noticed that the QETpy build by Travis CI was erroring on the installation of matplotlib, so it had nothing to do with our code. Some googling told me that the latest version of conda made installing some packages a little wonky. Well, I figured out that if I changed the channel that matplotlib was using to install, then the installation would work fine.

I also removed the seaborn stuff from the package, since it is no longer a requirement (it got pushed to RQpy).