### PR TITLE
Update .travis.yml so builds are only run on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+  - master
+
 language: python
   - 3.6
   - 3.7


### PR DESCRIPTION
Made it so Travis CI only runs build on master/pull requests. This makes it so we don't get superfluous builds run on development branches, which we would expect to fail (then we get emails we don't care about, and it just gets annoying).