### PR TITLE
Add cutoff frequency option to dIdV fitting

### DIFF
--- a/qetpy/plotting/_didv_plotting.py
+++ b/qetpy/plotting/_didv_plotting.py
@@ -419,9 +419,12 @@ def plot_re_im_didv(didv, poles="all", plotpriors=True, lgcsave=False, savepath=
     cost_vals = [didv.fitcost1, didv.fitcost2, didv.fitcost3, didv.fitcost2priors]
     fit_vals = [didv.fitparams1, didv.fitparams2, didv.fitparams3, didv.fitparams2priors]
 
-    min_cost_idx = min((val, ii) for ii, val in enumerate(cost_vals) if val is not None)[1]
+    if all(fv is None for fv in fit_vals):
+        best_time_offset = 0
+    else:
+        min_cost_idx = min((val, ii) for ii, val in enumerate(cost_vals) if val is not None)[1]
+        best_time_offset = fit_vals[min_cost_idx][-1]
 
-    best_time_offset = fit_vals[min_cost_idx][-1]
     time_phase = np.exp(2.0j * np.pi * best_time_offset * didv.freq)
 
     phase_correction = lambda x: np.exp(2.0j * np.pi * x * didv.freq)
@@ -624,9 +627,12 @@ def plot_abs_phase_didv(didv, poles="all", plotpriors=True, lgcsave=False, savep
     cost_vals = [didv.fitcost1, didv.fitcost2, didv.fitcost3, didv.fitcost2priors]
     fit_vals = [didv.fitparams1, didv.fitparams2, didv.fitparams3, didv.fitparams2priors]
 
-    min_cost_idx = min((val, ii) for ii, val in enumerate(cost_vals) if val is not None)[1]
+    if all(fv is None for fv in fit_vals):
+        best_time_offset = 0
+    else:
+        min_cost_idx = min((val, ii) for ii, val in enumerate(cost_vals) if val is not None)[1]
+        best_time_offset = fit_vals[min_cost_idx][-1]
 
-    best_time_offset = fit_vals[min_cost_idx][-1]
     time_phase = np.exp(2.0j * np.pi * best_time_offset * didv.freq)
 
     phase_correction = lambda x: np.exp(2.0j * np.pi * x * didv.freq)

--- a/test/test_detcal.py
+++ b/test/test_detcal.py
@@ -61,6 +61,10 @@ def test_didv():
     )
 
     didvfit.processtraces()
+
+    didvfit.plot_re_im_didv()
+    didvfit.plot_abs_phase_didv()
+
     didvfit.doallfits()
     didvfit.plot_full_trace(poles=[2, 3], lgcsave=True, savename="test")
     didvfit.plot_full_trace(poles="all", plotpriors=True)


### PR DESCRIPTION
I've added an optional argument `fcutoff` to the `DIDV` class methods `dopriorsfit`, `dofit`, and `doallfits`. This allows the user to specify a maximum frequency, after which the fit will ignore the values. This is useful if there are some issues with the data, such that the very high frequencies would otherwise substantially affect the fitting routine.

Also did a little bit of white space cleanup.

Lastly, I noticed that the plotting methods `plot_re_im_didv` and `plot_abs_phase_didv` would fail if the user had not done any of the fits yet. Sometimes, we want to look at these without having run the fits. So, I made this possible!