### PR TITLE
Add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,11 @@ setup(
     packages=find_packages(), 
     zip_safe=False,
     cmdclass={
-            'clean': CleanCommand,
-            }
-    )
+        'clean': CleanCommand,
+    },
+    install_requires=[
+        'numpy',
+        'scipy',
+        'matplotlib',
+    ]
+)


### PR DESCRIPTION
As in https://github.com/ucbpylegroup/RQpy/pull/158, it is good practice to pass the minimal installation requirements to the `setup` function in `setup.py` via `install_requires`. This PR does that.