### PR TITLE
Update path to QETpy in installation instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,7 +10,7 @@ at the command line:
 
 
 
-Or, if you want to work with the lastest development version. Clone the repository from: https://github.com/berkeleycdms/qetpy.git.
+Or, if you want to work with the lastest development version. Clone the repository from: https://github.com/ucbpylegroup/qetpy.git.
 Then within the repository, from the command line:
 
 ::


### PR DESCRIPTION
Noticed an old path in the `install.rst` file in the documentation.