### PR TITLE
Update readme with new installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI version](https://badge.fury.io/py/QETpy.svg)](https://badge.fury.io/py/QETpy)
 
 
-QETpy (Quasiparticle-trap-assisted Electrothermal-feedback Transition-edge sensors) provides a general set of tools for TES based detector calibration and analysis. It contains submodules for noise modeling, IV analysis, complex impedance fitting, non-linear optimum filter pulse fitting, and many other useful detector R&D analysis tools. This package is _NOT_ intended to contain any tools specific to a particular analysis. It is also be DAQ independent, meaning it contains no IO functionality. It is assumed that the user is able to load their data as NumPy arrays separate from QETpy. 
+QETpy (Quasiparticle-trap-assisted Electrothermal-feedback Transition-edge sensors) provides a general set of tools for TES-based detector calibration and analysis. It contains submodules for noise modeling, IV analysis, complex impedance fitting, nonlinear optimum filter pulse fitting, and many other useful detector R&D analysis tools. This package is _NOT_ intended to contain any tools specific to a particular analysis. It is also meant to be DAQ independent, meaning it contains no IO functionality. It is assumed that the user is able to load their data as NumPy arrays separate from QETpy. 
 
 * Documentation: [Docs](https://qetpy.readthedocs.io/en/latest/)
 * Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
@@ -19,12 +19,13 @@ To install the current stable version of QETpy, from the command line type
 
 `pip install --upgrade qetpy`
 
-Be aware, the version hosted on PyPi will likely be an older version than the version on GitHub. 
+Beware, the version hosted on PyPi will likely be an older version than the version on GitHub. 
 
-To install the most recent (stable) development version of QETpy, clone this repo, then from the top-level directory of the repo, type the following lines into your command line
+To install the most recent (stable) development version of QETpy, clone this repo, then from the top-level directory of the repo, type the following line into your command line
 
-`python setup.py clean`  
-`python setup.py install --user`
+`pip install .`
+
+You may need to add the `--user` flag if using a shared Python installation.
 
 This package requires python 3.6 or greater. A current version of Anaconda3 should be sufficient, however a conda environment file as well as a list of dependencies is provided (condaenv.yml and requirements.txt)
     


### PR DESCRIPTION
Updated the README to tell people to use `pip install .` to install QETpy, as is convention nowadays. Also avoids the `clean` step. Also fixed some typos/grammar issues.

Closes #92.