### PR TITLE
Add pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+]


### PR DESCRIPTION
Added the `pyproject.toml` file specifying the minimum build system reqs, as recommended in [PEP 518](https://www.python.org/dev/peps/pep-0518/).