### PR TITLE
Add error checking for when DIDV data should be resampled

### DIFF
--- a/qetpy/core/didv/_base_didv.py
+++ b/qetpy/core/didv/_base_didv.py
@@ -384,7 +384,7 @@ class _BaseDIDV(object):
 
     def __init__(self, rawtraces, fs, sgfreq, sgamp, rsh, tracegain=1.0,
                  r0=0.3, rp=0.005, dutycycle=0.5, add180phase=False,
-                 dt0=10.0e-6):
+                 dt0=10.0e-6, autoresample=False):
         """
         Initialization of the _BaseDIDV class object
 
@@ -432,20 +432,38 @@ class _BaseDIDV(object):
             finding the value on the first run if it the initial value
             is far from the actual value, so a solution is to do this
             iteratively.
+        autoresample : bool, optional
+            If True, the initialization will automatically resample
+            the data so that `fs` / `sgfreq` is an integer, which
+            ensures that an arbitrary number of signal-generator
+            periods can fit in an integer number of time bins. See
+            `qetpy.utils.resample_data` for more info.
 
         """
 
-        if np.mod(fs, sgfreq)!=0:
+        if np.mod(fs, sgfreq)!=0 and not autoresample:
             raise ValueError(
                 '`fs` and `sgfreq` do not divide to an integer. If '
                 'these are the true values, please resample the data '
                 'and use the resampled versions of `rawtraces` and '
-                '`fs`. To do this, we recommend using'
-                '`scipy.signal.resample_poly`.'
+                '`fs`. To do this, try using the optional argument '
+                '`autoresample` or using `scipy.signal.resample_poly`.'
             )
+        elif np.mod(fs, sgfreq)!=0 and autoresample:
+            warnings.warn(
+                'The data is being autoresampled. This may have '
+                'unintended effects on the DIDV fit in frequency '
+                'space.'
+            )
+            resampled_rawtraces, resampled_fs = qp.utils.resample_data(
+                rawtraces, fs, sgfreq,
+            )
+            self._rawtraces = resampled_rawtraces
+            self._fs = resampled_fs
+        else:
+            self._rawtraces = rawtraces
+            self._fs = fs
 
-        self._rawtraces = rawtraces
-        self._fs = fs
         self._sgfreq = sgfreq
         self._sgamp = sgamp
         self._r0 = r0

--- a/qetpy/core/didv/_base_didv.py
+++ b/qetpy/core/didv/_base_didv.py
@@ -4,6 +4,8 @@ from numpy import pi
 from scipy.optimize import least_squares, fsolve
 from scipy.fftpack import fft, ifft, fftfreq
 
+from qetpy.utils import resample_data
+
 
 __all__ = [
     "stdcomplex",
@@ -455,7 +457,7 @@ class _BaseDIDV(object):
                 'unintended effects on the DIDV fit in frequency '
                 'space.'
             )
-            resampled_rawtraces, resampled_fs = qp.utils.resample_data(
+            resampled_rawtraces, resampled_fs = resample_data(
                 rawtraces, fs, sgfreq,
             )
             self._rawtraces = resampled_rawtraces

--- a/qetpy/core/didv/_base_didv.py
+++ b/qetpy/core/didv/_base_didv.py
@@ -435,6 +435,15 @@ class _BaseDIDV(object):
 
         """
 
+        if np.mod(fs, sgfreq)!=0:
+            raise ValueError(
+                '`fs` and `sgfreq` do not divide to an integer. If '
+                'these are the true values, please resample the data '
+                'and use the resampled versions of `rawtraces` and '
+                '`fs`. To do this, we recommend using'
+                '`scipy.signal.resample_poly`.'
+            )
+
         self._rawtraces = rawtraces
         self._fs = fs
         self._sgfreq = sgfreq

--- a/qetpy/core/didv/_didv.py
+++ b/qetpy/core/didv/_didv.py
@@ -129,7 +129,7 @@ class DIDV(_BaseDIDV, _PlotDIDV):
 
     def __init__(self, rawtraces, fs, sgfreq, sgamp, rsh, tracegain=1.0,
                  r0=0.3, rp=0.005, dutycycle=0.5, add180phase=False,
-                 dt0=10.0e-6):
+                 dt0=10.0e-6, autoresample=False):
         """
         Initialization of the DIDV class object
 
@@ -177,6 +177,12 @@ class DIDV(_BaseDIDV, _PlotDIDV):
             finding the value on the first run if it the initial value
             is far from the actual value, so a solution is to do this
             iteratively.
+        autoresample : bool, optional
+            If True, the initialization will automatically resample
+            the data so that `fs` / `sgfreq` is an integer, which
+            ensures that an arbitrary number of signal-generator
+            periods can fit in an integer number of time bins. See
+            `qetpy.utils.resample_data` for more info.
 
         """
 
@@ -192,6 +198,7 @@ class DIDV(_BaseDIDV, _PlotDIDV):
             dutycycle=dutycycle,
             add180phase=add180phase,
             dt0=dt0,
+            autoresample=autoresample,
         )
 
 

--- a/qetpy/core/didv/_didv_priors.py
+++ b/qetpy/core/didv/_didv_priors.py
@@ -24,7 +24,8 @@ class DIDVPriors(_BaseDIDV, _PlotDIDV):
     """
 
     def __init__(self, rawtraces, fs, sgfreq, sgamp, rsh, tracegain=1.0,
-                 dutycycle=0.5, add180phase=False, dt0=10.0e-6):
+                 dutycycle=0.5, add180phase=False, dt0=10.0e-6,
+                 autoresample=False):
         """
         Initialization of the DIDVPriors class object
 
@@ -59,6 +60,12 @@ class DIDVPriors(_BaseDIDV, _PlotDIDV):
         dt0 : float, optional
             The value of the starting guess for the time offset of the
             didv when fitting. See Notes for more information.
+        autoresample : bool, optional
+            If True, the initialization will automatically resample
+            the data so that `fs` / `sgfreq` is an integer, which
+            ensures that an arbitrary number of signal-generator
+            periods can fit in an integer number of time bins. See
+            `qetpy.utils.resample_data` for more info.
 
         Notes
         -----
@@ -81,6 +88,7 @@ class DIDVPriors(_BaseDIDV, _PlotDIDV):
             dutycycle=dutycycle,
             add180phase=add180phase,
             dt0=dt0,
+            autoresample=autoresample,
         )
 
 

--- a/qetpy/utils/_utils.py
+++ b/qetpy/utils/_utils.py
@@ -1,6 +1,8 @@
 import numpy as np
 from scipy import interpolate, signal, constants
 from scipy import ndimage
+from sympy.ntheory import factorrat
+from sympy.core.symbol import S
 
 
 __all__ = [
@@ -16,6 +18,8 @@ __all__ = [
     "shift",
     "make_template",
     "estimate_g",
+    "resample_factors",
+    "resample_data",
 ]
 
 
@@ -62,6 +66,116 @@ def shift(arr, num, fill_value=0):
         )
 
     return result
+
+
+def resample_factors(fs, sgfreq):
+    """
+    Function for determining the upsampling and downsampling factors
+    needed to ensure that `fs`/`sgfreq` is an integer. These factor are
+    to be used with `scipy.signal.resample_poly`. Note that these
+    factors are not a unique solution, but a simple one.
+
+    Parameters
+    ----------
+    fs : int
+        The digitization rate of the data in Hz.
+    sgfreq : int
+        The frequency of the square wave from the signal generator in
+        Hz.
+
+    Returns
+    -------
+    up : int
+        The upsampling factor.
+    down : int
+        The downsampling factor.
+
+    Notes
+    -----
+    See the documentation for `scipy.signal.resample_poly` for more
+    information on these factors.
+
+    """
+
+    if int(fs) != fs:
+        raise ValueError('`fs` must be an integer to use this function')
+    if int(sgfreq) != sgfreq:
+        raise ValueError('`sgfreq` must be an integer to use this function')
+
+    rfacs = factorrat(S(int(fs)) / int(sgfreq))
+    numer = [key for key in rfacs if rfacs[key] > 0]
+    denom = [key for key in rfacs if rfacs[key] < 0]
+
+    if len(denom)==0:
+        return 1, 1
+
+    down = np.multiply.reduce(numer)
+    up = round(down / min(denom)) * min(denom)
+
+    # round up if `sgfreq` is prime (otherwise would return 0)
+    if up==0:
+        up = np.ceil(down / min(denom)).astype(int) * min(denom)
+
+    return up, down
+
+
+def resample_data(x, fs, sgfreq, **kwargs):
+    """
+    Function that uses `resample_factors` and
+    `scipy.signal.resample_poly` to automatically resample the data to
+    ensure that `fs`/`sgfreq` is an integer.
+
+    Parameters
+    ----------
+    x : array_like
+        The data to be resampled.
+    fs : int
+        The digitization rate of the data in Hz.
+    sgfreq : int
+        The frequency of the square wave from the signal generator in
+        Hz.
+    axis : int, optional
+        The axis of `x` that is resampled. Default is -1.
+    window : string, tuple, or array_like, optional
+        Desired window to use to design the low-pass filter, or the FIR
+        filter coefficients to employ.
+    padtype : string, optional
+        `constant`, `line`, `mean`, `median`, `maximum`, `minimum` or
+        any of the other signal extension modes supported by
+        `scipy.signal.upfirdn`. Changes assumptions on values beyond
+        the boundary. If `constant`, assumed to be `cval` (default
+        zero). If `line` assumed to continue a linear trend defined by
+        the first and last points. `mean`, `median`, `maximum` and
+        `minimum` work as in `np.pad` and assume that the values beyond
+        the boundary are the mean, median, maximum or minimum
+        respectively of the array along the axis. Default is
+        `constant`.
+    cval : float, optional
+        Value to use if `padtype='constant'`. Default is zero.
+
+    Returns
+    -------
+    resampled_x : ndarray
+        The resampled data.
+    resampled_fs : float
+        The digitization rate of `resampled_x` in Hz.
+
+    Notes
+    -----
+    The `kwargs` are each passed to the `scipy.signal.resample_poly`
+    function, from which we took the text for this dosctring for those
+    parameters.
+
+    """
+
+    if 'axis' not in kwargs:
+        kwargs['axis'] = -1
+
+    up, down = resample_factors(fs, sgfreq)
+    resampled_x = signal.resample_poly(x, up, down, **kwargs)
+    resampled_fs =  fs * up / down
+
+    return resampled_x, resampled_fs
 
 
 def make_template(t, tau_r, tau_f, offset=0):

--- a/qetpy/utils/_utils.py
+++ b/qetpy/utils/_utils.py
@@ -116,7 +116,7 @@ def resample_factors(fs, sgfreq):
     if up==0:
         up = np.ceil(down / min(denom)).astype(int) * min(denom)
 
-    return up, down
+    return int(up), int(down)
 
 
 def resample_data(x, fs, sgfreq, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ scipy>=1.1.0
 Sphinx>=1.6.3
 sphinx-rtd-theme>=0.4.1
 sphinxcontrib-websupport>=1.0.1
-iminuit>=1.3
+iminuit>=1.3,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Sphinx>=1.6.3
 sphinx-rtd-theme>=0.4.1
 sphinxcontrib-websupport>=1.0.1
 iminuit>=1.3,<2.0
+sympy>=1.4

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
         'numpy',
         'scipy',
         'matplotlib',
-        'iminuit',
+        'iminuit<2.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,6 @@ setup(
         'scipy',
         'matplotlib',
         'iminuit<2.0',
+        'sympy',
     ]
 )

--- a/test/test_didv.py
+++ b/test/test_didv.py
@@ -1,5 +1,7 @@
 import qetpy as qp
 import numpy as np
+import pytest
+
 
 def _initialize_didv(poles, priors):
     """Function for initializing dIdV data"""
@@ -110,6 +112,26 @@ def _run_plotting_suite(didvfit, poles):
     didvfit.plot_re_im_didv()
     didvfit.plot_re_im_didv(saveplot=True, savename='test')
 
+def _raise_errors():
+    """
+    Function for asserting certain errors are raised
+    for specific cases.
+
+    """
+
+    error_str = "`fs` and `sgfreq` do not divide to an integer."
+
+    with pytest.raises(ValueError) as excinfo:
+        didvfit = qp.DIDV(
+            None,
+            625e3, # fs
+            30, # sgfreq
+            None,
+            None,
+        )
+
+    assert error_str in str(excinfo.value)
+    
 
 def test_didv():
     """Function for testing the DIDV and DIDVPriors classes."""
@@ -130,3 +152,6 @@ def test_didv():
                 ),
                 rtol=1e-2,
             )
+
+    _raise_errors()
+

--- a/test/test_didv.py
+++ b/test/test_didv.py
@@ -3,14 +3,13 @@ import numpy as np
 import pytest
 
 
-def _initialize_didv(poles, priors):
+def _initialize_didv(poles, priors, sqfreq=100):
     """Function for initializing dIdV data"""
     np.random.seed(0)
 
     rsh = 5e-3
     rbias_sg = 20000
     fs = 625e3
-    sgfreq = 100
     sgamp = 0.009381 / rbias_sg
 
     rfb = 5000
@@ -131,7 +130,27 @@ def _raise_errors():
         )
 
     assert error_str in str(excinfo.value)
+
+
+def _autoresample():
+    """
+    Function for testing the autoresample kwarg for _BaseDIDV.
+
+    """
+
+    didvfit, true_params = _initialize_didv(2, False, sgfreq=90)
+
+    assert np.isclose(
+        qp.complexadmittance(
+            1e4, **didvfit.fitresult(2)['smallsignalparams'],
+        ),
+        qp.complexadmittance(
+            1e4, **true_params,
+        ),
+        rtol=1e-2,
+    )
     
+
 
 def test_didv():
     """Function for testing the DIDV and DIDVPriors classes."""
@@ -154,4 +173,4 @@ def test_didv():
             )
 
     _raise_errors()
-
+    _autoresample()

--- a/test/test_didv.py
+++ b/test/test_didv.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 
-def _initialize_didv(poles, priors, sqfreq=100):
+def _initialize_didv(poles, priors, sgfreq=100):
     """Function for initializing dIdV data"""
     np.random.seed(0)
 
@@ -149,7 +149,7 @@ def _autoresample():
         ),
         rtol=1e-2,
     )
-    
+
 
 
 def test_didv():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -233,6 +233,14 @@ def test_resample():
     assert all(res[ii] == expected_res[ii] for ii in range(2))
 
     fs = 1.25e6
+    sgfreq = 37
+
+    res = resample_factors(fs, sgfreq)
+    expected_res = [37, 10]
+
+    assert all(res[ii] == expected_res[ii] for ii in range(2))
+
+    fs = 1.25e6
     sgfreq = 30
 
     res = resample_factors(fs, sgfreq)


### PR DESCRIPTION
In the initialization of the `DIDV` and `DIDVPriors` classes, there is a case where the processing will fail with a red herring of an error message on a unrelated line of code (having to do with `flatinds`). This error happens when the data itself has a digitization rate `fs` and square-wave signal-generator frequency `sgfreq` that does not divide cleanly to an integer. That is, `fs/sgfreq` is not an integer.

This is a problem because it makes it so we cannot fit an arbitrary number of signal-generator periods within an integer number of time bins. When data is taken like this, then it must be resampled in order to use the fitting routine. Since resampling the data can affect it in frequency space, data should generally be taken with this factor dividing cleanly.

In order to make it clear that this is the problem (rather than the unrelated line of code that is first errored on) and give a possible solution, we've done the following:

- Added an optional argument to the DIDV initialization `autoresample`
- Explicit check that `np.mod(fs / sgfreq)==0` in the initialization of the class
- If `autoresample` is `False`, then an error message is returned, which recommends using `scipy.signal.resample_poly` to resample the data or the `autoresample` flag.
- If `autoresample` is `True`, then we take advantage of the new `resample_factors` and `resample_data` functions to resample the data so that the resampled digitization frequency is divisible by the signal-generator frequency.
- The unit tests for the various new functions have been added and have full code coverage on the new code.