### PR TITLE
Update sgamp docstring description to be more specific

### DIFF
--- a/qetpy/core/didv/_base_didv.py
+++ b/qetpy/core/didv/_base_didv.py
@@ -402,8 +402,8 @@ class _BaseDIDV(object):
         sgfreq : float
             Frequency of the signal generator, in Hz
         sgamp : float
-            Amplitude of the signal generator, in Amps (equivalent to
-            jitter in the QET bias)
+            Peak-to-peak size of the square wave supplied by the signal
+            generator, in Amps (equivalent to jitter in the QET bias)
         rsh : float
             Shunt resistance in the circuit, Ohms
         tracegain : float, optional

--- a/qetpy/core/didv/_didv.py
+++ b/qetpy/core/didv/_didv.py
@@ -39,8 +39,8 @@ def didvinitfromdata(tmean, didvmean, didvstd, offset, offset_err, fs, sgfreq,
     sgfreq : float
         Frequency of the signal generator, in Hz
     sgamp : float
-        Amplitude of the signal generator, in Amps (equivalent to
-        jitter in the QET bias)
+        Peak-to-peak size of the square wave supplied by the signal
+        generator, in Amps (equivalent to jitter in the QET bias)
     rsh : float
         Shunt resistance in the circuit, Ohms
     r0 : float, optional
@@ -145,8 +145,8 @@ class DIDV(_BaseDIDV, _PlotDIDV):
         sgfreq : float
             Frequency of the signal generator, in Hz
         sgamp : float
-            Amplitude of the signal generator, in Amps (equivalent to
-            jitter in the QET bias)
+            Peak-to-peak size of the square wave supplied by the signal
+            generator, in Amps (equivalent to jitter in the QET bias)
         rsh : float
             Shunt resistance in the circuit, Ohms
         tracegain : float, optional

--- a/qetpy/core/didv/_didv_priors.py
+++ b/qetpy/core/didv/_didv_priors.py
@@ -41,8 +41,8 @@ class DIDVPriors(_BaseDIDV, _PlotDIDV):
         sgfreq : float
             Frequency of the signal generator, in Hz
         sgamp : float
-            Amplitude of the signal generator, in Amps (equivalent to
-            jitter in the QET bias)
+            Peak-to-peak size of the square wave supplied by the signal
+            generator, in Amps (equivalent to jitter in the QET bias)
         rsh : float
             Expected shunt resistance in the circuit, Ohms
         tracegain : float, optional


### PR DESCRIPTION
In the DIDV code, the `sgamp` argument is a little bit unclear if it is the zero-to-peak or peak-to-peak amplitude of the square wave, so I've updated the docstrings to specify peak-to-peak to help clarify this.

Changed in the files
- `qetpy/core/didv/_base_didv.py`
- `qetpy/core/didv/_didv.py`
- `qetpy/core/didv/_didv_priors.py`