### PR TITLE
Ensure sphinx is of version 1.8 or greater to build docs

### DIFF
--- a/condaenv.yml
+++ b/condaenv.yml
@@ -9,7 +9,7 @@ dependencies:
   - pandas=0.23.0=py36h637b7d7_0
   - python=3.6.5=hc3d631a_2
   - scipy=1.1.0=py36hfc37229_0
-  - sphinx=1.7.4=py36_0
+  - sphinx>=1.8
   - sphinxcontrib=1.0=py36h6d0f590_1
   - sphinxcontrib-websupport=1.0.1=py36hb5cb234_1
   - pip:


### PR DESCRIPTION
Due to a change in order of how readthedocs is compiling the documentation, we should ensure that `nbsphinx` and `sphinx` are using compatible versions. Since `nbsphinx` requires `sphinx` version 1.8 or greater, I've changed the version in `condaenv.yml` to specify that. Should fix the currently failing docs build.